### PR TITLE
GetKernelRelease function

### DIFF
--- a/lpfs.go
+++ b/lpfs.go
@@ -16,7 +16,7 @@ const (
 	procdir_uptime           string = "/proc/uptime"
 	procdir_per_process_stat string = "/stat"
 	procdir_meminfo		 string = "/proc/meminfo"
-	procdir_version		 string = "/proc/version"
+	procdir_osrelease	 string = "/proc/sys/kernel/osrelease"
 )
 
 //	Procstat contains process stat available in /proc/<pid>/stat.
@@ -816,14 +816,11 @@ func GetMemCached() (int, error) {
 
 //	GetKernelRelease returns the kernel version with additional information.
 func GetKernelRelease() (string, error) {
-	dat, err := os.ReadFile(procdir_version)
+	dat, err := os.ReadFile(procdir_osrelease)
 	if err != nil {
-		fmt.Errorf("unable to read the file %v", procdir_version)
+		fmt.Errorf("unable to read the file %v", procdir_osrelease)
+		return "", err
 	}
 
-	dat_s := strings.Split(string(dat), " ")
-
-	s := strings.Fields(dat_s[2])[0]
-
-	return s, err
+	return string(dat), err
 }

--- a/lpfs.go
+++ b/lpfs.go
@@ -15,7 +15,8 @@ const (
 	procdir_stat             string = "/proc/stat"
 	procdir_uptime           string = "/proc/uptime"
 	procdir_per_process_stat string = "/stat"
-	procdir_meminfo			 string = "/proc/meminfo"
+	procdir_meminfo		 string = "/proc/meminfo"
+	procdir_version		 string = "/proc/version"
 )
 
 //	Procstat contains process stat available in /proc/<pid>/stat.
@@ -809,6 +810,20 @@ func GetMemCached() (int, error) {
 		fmt.Errorf("error parsing %v", dat_s)
 		return 0, err
 	}
+
+	return s, err
+}
+
+//	GetKernelRelease returns the kernel version with additional information.
+func GetKernelRelease() (string, error) {
+	dat, err := os.ReadFile(procdir_version)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_version)
+	}
+
+	dat_s := strings.Split(string(dat), " ")
+
+	s := strings.Fields(dat_s[2])[0]
 
 	return s, err
 }

--- a/lpfs_test.go
+++ b/lpfs_test.go
@@ -156,5 +156,13 @@ func TestMeminfo(t *testing.T) {
 		t.Errorf("%v", err)
 	}
 	fmt.Printf("GetMemCached(): %v, err: %v\n", mc, err)
+}
 
+//	TestVersion tests all functions that get data from /proc/version.
+func TestVersion(t *testing.T) {
+	kr , err := GetKernelRelease()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetKernelRelease(): %v, err: %v\n", kr, err)
 }

--- a/lpfs_test.go
+++ b/lpfs_test.go
@@ -158,8 +158,8 @@ func TestMeminfo(t *testing.T) {
 	fmt.Printf("GetMemCached(): %v, err: %v\n", mc, err)
 }
 
-//	TestVersion tests all functions that get data from /proc/version.
-func TestVersion(t *testing.T) {
+//	TestSysKernel tests all functions that get data from /proc/sys/kernel.
+func TestSysKernel(t *testing.T) {
 	kr , err := GetKernelRelease()
 	if err != nil {
 		t.Errorf("%v", err)


### PR DESCRIPTION
Adding function that returns kernel version and additional release information from /proc/version file and tests for it
```
$ go test
GetKernelRelease(): 6.2.10-arch1-1, err: <nil>
```