### PR TITLE
CPU functions from /proc/stat

### DIFF
--- a/lpfs.go
+++ b/lpfs.go
@@ -328,6 +328,186 @@ func GetUptimeIdle() (float64, error) {
 	return ui, nil
 }
 
+//	GetCpuUserTime returns the amount of time spent in user mode (USER_HZ).
+func GetCpuUserTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[2]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuNiceTime returns the amount of time spent in user mode with low priority (USER_HZ).
+func GetCpuNiceTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[3]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuSystemTime returns the amount of time spent in system mode (USER_HZ).
+func GetCpuSystemTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[4]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuIdleTime returns the amount of time spent in the idle task (USER_HZ times UptimeIdle).
+func GetCpuIdleTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[5]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuIowaitTime returns the amount of time waiting for I/O to complete (USER_HZ).
+func GetCpuIowaitTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[6]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuIrqTime returns the amount of time servicing interrupts (USER_HZ).
+func GetCpuIrqTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[7]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuSoftirqTime returns the amount of time servicing softirqs(USER_HZ).
+func GetCpuSoftirqTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[8]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuStealTime returns the amount of time spent in other operating systems when running in a virtualized environment (USER_HZ).
+func GetCpuStealTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[9]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuGuestTime returns the amount of time spent running a virtual CPU for guest operating systems (USER_HZ).
+func GetCpuGuestTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[10]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
+//	GetCpuGuestNiceTime returns the amount of time spent running a niced virtual CPU for guest operating systems (USER_HZ).
+func GetCpuGuestNiceTime() (int, error) {
+	dat, err := os.ReadFile(procdir_stat)
+	if err != nil {
+		fmt.Errorf("unable to read the file %v", procdir_stat)
+		return 0, err
+	}
+
+	dat_s := strings.Split(string(dat), " ")[11]
+
+	s, err := strconv.Atoi(dat_s)
+	if err != nil {
+		fmt.Errorf("error parsing %v", dat_s)
+	}
+
+	return s, nil
+}
+
 //	GetProcessesBlockedSize returns the number of blocked processes in the system.
 // 	FIXME
 func GetProcessesBlockedSize() (int, error) {

--- a/lpfs_test.go
+++ b/lpfs_test.go
@@ -93,15 +93,74 @@ func TestUptime(t *testing.T) {
 }
 
 //	TestStat tests all functions that get data from /proc/stat.
-/*
 func TestStat(t *testing.T) {
+	ut, err := GetCpuUserTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuUserTime(): %v, err: %v\n", ut, err)
+
+	nt, err := GetCpuNiceTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuNiceTime(): %v, err: %v\n", nt, err)
+
+	syst, err := GetCpuSystemTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuSystemTime(): %v, err: %v\n", syst, err)
+
+	it, err := GetCpuIdleTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuIdleTime(): %v, err: %v\n", it, err)
+
+	iot, err := GetCpuIowaitTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuIowaitTime(): %v, err: %v\n", iot, err)
+
+	irqt, err := GetCpuIrqTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuIrqTime(): %v, err: %v\n", irqt, err)
+
+	sirqt, err := GetCpuSoftirqTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuSoftirqTime(): %v, err: %v\n", sirqt, err)
+
+	st, err := GetCpuStealTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuStealTime(): %v, err: %v\n", st, err)
+
+	gt, err := GetCpuGuestTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuGuestTime(): %v, err: %v\n", gt, err)
+
+	gnt, err := GetCpuGuestNiceTime()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetCpuGuestNiceTime(): %v, err: %v\n", gnt, err)
+/*
 	blksz, err := GetProcessesBlockedSize()
 	if err != nil {
 		t.Errorf("%v", err)
 	}
 	fmt.Printf("GetProcessesBlockedSize(): %v, err: %v\n", blksz, err)
-}
 */
+}
 
 // 	TestPerProcess tests all functions that get data from /proc/<pid>/.
 func TestPerProcess(t *testing.T) {


### PR DESCRIPTION
Adding 10 CPU related functions that return information from /proc/stat file and tests for each one.
```golang
GetCpuUserTime()
GetCpuNiceTime()
GetCpuSystemTime()
GetCpuIdleTime()
GetCpuIowaitTime()
GetCpuIrqTime()
GetCpuSoftirqTime()
GetCpuStealTime()
GetCpuGuestTime()
GetCpuGuestNiceTime()
```
```golang
$ go test
GetCpuUserTime(): 298071, err: <nil>
GetCpuNiceTime(): 2, err: <nil>
GetCpuSystemTime(): 58978, err: <nil>
GetCpuIdleTime(): 1265339, err: <nil>
GetCpuIowaitTime(): 1130, err: <nil>
GetCpuIrqTime(): 5787, err: <nil>
GetCpuSoftirqTime(): 3656, err: <nil>
GetCpuStealTime(): 0, err: <nil>
GetCpuGuestTime(): 0, err: <nil>
GetCpuGuestNiceTime(): 0, err: <nil>
```