### PR TITLE
GetKernelModules function

### DIFF
--- a/lpfs_test.go
+++ b/lpfs_test.go
@@ -225,3 +225,12 @@ func TestSysKernel(t *testing.T) {
 	}
 	fmt.Printf("GetKernelRelease(): %v, err: %v\n", kr, err)
 }
+
+//	TestModules tests all functions that get data from /proc/modules.
+func TestModules(t *testing.T) {
+	km, err := GetKernelModules()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	fmt.Printf("GetKernelModules(): %v, err %v\n", km, err)
+}


### PR DESCRIPTION
Adding a function that returns kernel modules currently loaded from /proc/modules file and tests for it.

```bash
$ go test
GetKernelModules(): [{zfs 3825664 6 [] Live 0x0000000000000000} {zunicode 348160 1 [zfs] Live 0x0000000000000000} 
{zzstd 491520 1 [zfs] Live 0x0000000000000000} {zlua 163840 1 [zfs] Live 0x0000000000000000} {zavl 20480 1 [zfs] Live 0x0000000000000000} 
{icp 323584 1 [zfs] Live 0x0000000000000000} {zcommon 106496 2 [zfs icp] Live 0x0000000000000000} {znvpair 98304 2 [zfs zcommon] Live 0x0000000000000000} 
{spl 118784 6 [zfs zzstd zavl icp zcommon znvpair] Live 0x0000000000000000} ...], err <nil>
```

```go
modules, _ := lpfs.GetKernelModules()

modules[0].Name      // zfs
modules[0].Size      // 3825664
modules[0].Instances // 6
modules[0].UsedBy    // []
modules[0].State     // Live
modules[0].MemOffset // 0x0000000000000000
```